### PR TITLE
Use integer value in WEB_CONCURRENCY assert

### DIFF
--- a/images/hypercorn_conf.py
+++ b/images/hypercorn_conf.py
@@ -63,7 +63,7 @@ web_concurrency = web_concurrency = os.getenv("WEB_CONCURRENCY", None)
 
 if web_concurrency:
     use_web_concurrency = int(web_concurrency)
-    assert web_concurrency > 0, "WEB_CONCURRENCY Must be non zero"
+    assert use_web_concurrency > 0, "WEB_CONCURRENCY Must be non zero"
 else:
     use_web_concurrency = max(int(default_web_concurrency), 2)
     if workers_max:


### PR DESCRIPTION
This setting fails since you get a ValueError in the assert (comparing str w/ int).